### PR TITLE
support hs2019 hidden algorithm in signing and verifying

### DIFF
--- a/lib/signer.js
+++ b/lib/signer.js
@@ -234,7 +234,9 @@ RequestSigner.prototype.sign = function (cb) {
       cb(e);
       return;
     }
-    alg = (this.rs_alg[0] || this.rs_key.type) + '-' + sigObj.hashAlgorithm;
+    if (!sigObj.hideAlgorithm) {
+      alg = (this.rs_alg[0] || this.rs_key.type) + '-' + sigObj.hashAlgorithm;
+    }
     var signature = sigObj.toString();
     authz = FormatAuthz('Signature ', {
       keyId: this.rs_keyId,
@@ -303,6 +305,9 @@ module.exports = {
    *                              signing algorithm for the type of key given
    *                   - {String} httpVersion optional; defaults to '1.1'.
    *                   - {Boolean} strict optional; defaults to 'false'.
+   *                   - {Boolean} hideAlgorithm optional; if true, hides
+   *                              algorithm by writing "hs2019" to signature;
+   *                              defaults to 'false'.
    *                   - {int}    expiresIn optional; defaults to 60. The
    *                              seconds after which the signature should
    *                              expire;
@@ -326,6 +331,7 @@ module.exports = {
     assert.optionalString(options.opaque, 'options.opaque');
     assert.optionalArrayOfString(options.headers, 'options.headers');
     assert.optionalString(options.httpVersion, 'options.httpVersion');
+    assert.optionalBool(options.hideAlgorithm, 'options.hideAlgorithm');
     assert.optionalNumber(options.expiresIn, 'options.expiresIn');
     assert.optionalString(options.keyPassphrase, 'options.keyPassphrase');
 
@@ -377,7 +383,7 @@ module.exports = {
 
     var params = {
       'keyId': options.keyId,
-      'algorithm': options.algorithm
+      'algorithm': options.hideAlgorithm ? 'hs2019' : options.algorithm
     };
 
     var i;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,7 +13,8 @@ var HASH_ALGOS = {
 var PK_ALGOS = {
   'rsa': true,
   'dsa': true,
-  'ecdsa': true
+  'ecdsa': true,
+  'ed25519': true
 };
 
 var HEADER = {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -36,6 +36,10 @@ function InvalidAlgorithmError(message) {
 util.inherits(InvalidAlgorithmError, HttpSignatureError);
 
 function validateAlgorithm(algorithm) {
+  if (algorithm.toLowerCase() === 'hs2019') {
+    return (alg)
+  }
+
   var alg = algorithm.toLowerCase().split('-');
 
   if (alg.length !== 2) {

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -42,6 +42,8 @@ module.exports = {
     var algorithm = parsedSignature.algorithm.toLowerCase();
     if (algorithm === "hs2019" && options.overriddenAlgorithm) {
       algorithm = options.overriddenAlgorithm;
+    } else if (algorithm === "hs2019" && pubkey.type === "ed25519") {
+      algorithm = "ed25519-sha512";
     }
 
     var alg = validateAlgorithm(algorithm);

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -20,17 +20,31 @@ module.exports = {
    *
    * @param {Object} parsedSignature the object you got from `parse`.
    * @param {String} pubkey RSA/DSA private key PEM.
+   * @param {Object} options verifying parameters object:
+   *                   - {String} overriddenAlgorithm optional; if signature
+   *                              has hidden algorithm this tells the verifier
+   *                              the real algorithm to use.
    * @return {Boolean} true if valid, false otherwise.
    * @throws {TypeError} if you pass in bad arguments.
    * @throws {InvalidAlgorithmError}
    */
-  verifySignature: function verifySignature(parsedSignature, pubkey) {
+  verifySignature: function verifySignature(parsedSignature, pubkey, options) {
     assert.object(parsedSignature, 'parsedSignature');
+    if (options === undefined) {
+      options = {};
+    }
+    assert.optionalString(options.overriddenAlgorithm, 'options.overriddenAlgorithm');
+
     if (typeof (pubkey) === 'string' || Buffer.isBuffer(pubkey))
       pubkey = sshpk.parseKey(pubkey);
     assert.ok(sshpk.Key.isKey(pubkey, [1, 1]), 'pubkey must be a sshpk.Key');
 
-    var alg = validateAlgorithm(parsedSignature.algorithm);
+    var algorithm = parsedSignature.algorithm.toLowerCase();
+    if (algorithm === "hs2019" && options.overriddenAlgorithm) {
+      algorithm = options.overriddenAlgorithm;
+    }
+
+    var alg = validateAlgorithm(algorithm);
     if (alg[0] === 'hmac' || alg[0] !== pubkey.type)
       return (false);
 


### PR DESCRIPTION
Example usage of verifying a signature:

```ts
const crypto = await import("node:crypto");
const httpSignature = await import('http-signature');

const keyPub = crypto.createPublicKey({
  format: 'jwk',
  key: {
    kty: 'OKP',
    crv: 'Ed25519',
    x: 'V_rLFiU-SGY9aVv_fFpWV_Sl6HaYPnvQuZkYjm8KyIw',
  },
});

const parsed = httpSignature.parseRequest(req, {
  authorizationHeaderName: 'signature',
});
console.info('Parsed http signature', parsed);

// The `sshpk` library does not support JWK format, we need to first convert it to PEM
const keyPubPem = keyPub.export({ type: 'spki', format: 'pem' });

// For signatures with hidden algorithm (HS2019), by default it could infer from the key type
const verified = httpSignature.verifySignature(parsed, keyPubPem);

// or you could explicitly tell the library which algorithm to use
const verified = httpSignature.verifySignature(parsed, keyPubPem, {
   overriddenAlgorithm: 'ed25519-sha512',
});
```